### PR TITLE
Update read me and libGL.so.1 for RPi4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Enter SSH terminal and type follwing text to choose following versions:
 
 1.3.1 For newest branch 6510 for RPi 4 and up:
 
-    wget https://raw.githubusercontent.com/julenvitoria/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPi4/openbor-v6510-RPi4.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi4.sh
+    wget https://raw.githubusercontent.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPi4/openbor-v6510-RPi4.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi4.sh
 
 1.3.2 For newest branch 6510 for RPi 3 and up:
 
-    wget https://raw.githubusercontent.com/julenvitoria/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPi3/openbor-v6510-RPi3.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi3.sh
+    wget https://raw.githubusercontent.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPi3/openbor-v6510-RPi3.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi3.sh
 
 1.3.3 For newest branch 6510 for RPi 0/1:
 
-    wget https://raw.githubusercontent.com/julenvitoria/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPizero/openbor-v6510-RPi0.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi0.sh
+    wget https://raw.githubusercontent.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPizero/openbor-v6510-RPi0.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi0.sh
 
 
 Go to ES and select Configuration (the RetroJoy), select RetroPie Setup or just type sudo ~/RetroPie-Setup/retropie_setup.sh

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Enter SSH terminal and type follwing text to choose following versions:
 
     wget http://raw.githubusercontent.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-3400.sh -O /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-3400.sh
 
-1.3.1 For newest branch 6510 for RPi 4 and up:
+1.3.1 For newest branch 6510 for RPi 4B:
 
     wget https://raw.githubusercontent.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPi4/openbor-v6510-RPi4.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi4.sh
 
-1.3.2 For newest branch 6510 for RPi 3 and up:
+1.3.2 For newest branch 6510 for RPi 3B/3B+:
 
     wget https://raw.githubusercontent.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/master/scriptmodules/openbor-6xxx-RPi3/openbor-v6510-RPi3.sh -O- | tr -d '\r' > /home/pi/RetroPie-Setup/scriptmodules/ports/openbor-v6510-RPi3.sh
 


### PR DESCRIPTION
I forgot to change the readme before the pull request, I’m sorry... I discovered too that libGL.so.1seems to works better compiled with  -DBCMHOST=1 flag, without this flag sometimes there an error (rarely does that happen but it happens). Here I upload libGL.so.1 for RPi4, could you change it unzipped, please? Thanks a lot and sorry for the inconvenience
[libGL.so.1.zip](https://github.com/crcerror/OpenBOR-63xx-RetroPie-openbeta/files/4637417/libGL.so.1.zip)

